### PR TITLE
Fixes "url" not passing and some other things

### DIFF
--- a/Browser/ContextMenuHandler.cs
+++ b/Browser/ContextMenuHandler.cs
@@ -104,31 +104,15 @@ namespace Browser
 			}
 			if (id == OpenLinkInNewTab)
 			{
+                                var url = parameters.LinkUrl;
+                                // I have no idea why creating a variable fixed it.
 				if (myForm.InvokeRequired) 
 				{ 
-				    myForm.Invoke(new Action(() => myForm.CreateNewTab(parameters.LinkUrl))); 
+				    myForm.Invoke(new Action(() => myForm.CreateNewTab(url))); 
 				} else 
 				{ 
-				    myForm.CreateNewTab(parameters.LinkUrl);
-				}
-				/* 
-				Since we moved it to BrowserForm, we no longer need this code.
-				Feel free to delete this giant comment.
-				
-				AppContainer app = new AppContainer(); <-- our problem
-                var newtab = new TitleBarTab(app) { Content = new BrowserMain(parameters.LinkUrl) { Text = "New Tab" } }; <-- tab that we need to add to main content
-                app.Tabs.Add(newtab);
-		Also, why create a TitleBartab inside a TitleBarTab again?
-                //app.Tabs.Add(new TitleBarTab(app) 
-                //{
-                //    Content = new BrowserMain(parameters.LinkUrl) { Text = "New Tab" }
-                //});
-                app.SelectedTabIndex = app.SelectedTabIndex + 1; <-- Also a tip: use "++;" instead if you just want to add one like this: app.SelectedTabIndex++; 
-
-                
-                TitleBarTabsApplicationContext applicationContext = new TitleBarTabsApplicationContext();
-                applicationContext.Start(app);
-		*/
+				    myForm.CreateNewTab(url);
+				} 
 
 
                 return true;				

--- a/Browser/Form1.cs
+++ b/Browser/Form1.cs
@@ -107,9 +107,7 @@ namespace Browser
             InitializeComponent();
 
             ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
-            if (address == null || address == "")
-            {
-                WebBrowser = new ChromiumWebBrowser("about:blank")
+            WebBrowser = new ChromiumWebBrowser(string.IsNullOrWhiteSpace(address) ? "about:blank" : address) // using this method also eliminates white sapces like "  " and simplifies code
                 {
                     Anchor = AnchorStyles.Top | AnchorStyles.Bottom | AnchorStyles.Left | AnchorStyles.Right,
                     Location = new Point(0, 38),
@@ -119,20 +117,6 @@ namespace Browser
                     TabIndex = 6,
                     LifeSpanHandler = new NewTabLifespanHandler(this)
                 };
-            }
-            else
-            {
-                WebBrowser = new ChromiumWebBrowser(address)
-                {
-                    Anchor = AnchorStyles.Top | AnchorStyles.Bottom | AnchorStyles.Left | AnchorStyles.Right,
-                    Location = new Point(0, 38),
-                    MinimumSize = new Size(20, 20),
-                    Name = "webBrowser",
-                    Size = new Size(326, 251),
-                    TabIndex = 6,
-                    LifeSpanHandler = new NewTabLifespanHandler(this)
-                };
-            }
             mHandler = new ContextMenuHandler(this);
             WebBrowser.MenuHandler = mHandler;
             Controls.Add(WebBrowser);
@@ -203,18 +187,18 @@ namespace Browser
            if (ParentTabs.InvokeRequired) 
            {
                ParentTabs.Invoke(new Action(() => {
-                     ParentTabs.Tabs.Add(newtab);
-                     ParentTabs.SelectedTabIndex++; // similar to ParentTabs.SelectedIndex = ParentTabs.SelectedTabIndex + 1; or ParentTabs.SelectedTabIndex += 1;
+                     ParentTabs.Tabs.Insert(ParentTabs.SelectedTabIndex + 1, newtab);
+                     ParentTabs.SelectedTabIndex++;
                      ParentTabs.RedrawTabs();
-                     PrentTabs.Refresh();
+                     ParentTabs.Refresh();
                });
            }
            else 
            {
-               ParentTabs.Tabs.Add(newtab);
-               ParentTabs.SelectedTabIndex++; // similar to ParentTabs.SelectedIndex = ParentTabs.SelectedTabIndex + 1; or ParentTabs.SelectedTabIndex += 1;
+               ParentTabs.Tabs.Insert(ParentTabs.SelectedTabIndex + 1, newtab);
+               ParentTabs.SelectedTabIndex++;
                ParentTabs.RedrawTabs();
-               PrentTabs.Refresh();
+               ParentTabs.Refresh();
            }
         }
 


### PR DESCRIPTION
This PR doesn't just fixes the problem but also includes some tweaks to code.
 - Fixes url passing with creating a new variable and passing it to new void in browser form.
 - Tweaks app startup and empty address detection by using string.IsNullOrWhiteSpace() method
 - Fixes my typos

I noticed some problems on the way while debugging:
 - On Address change, some websites might not include favicon.ico in their parent folder. So I suggest using IDisplayHandler.OnFaviconUrlChange method. This caused an exception on some websites. 
 - Some addresses might not include ".com", I recommend using an advanced way to figure out if it is a search string or and URI. Luckily, my [HTAlt](https://github.com/Haltroy/HTAlt/blob/4ec92f790e72c7d0ec8b751b543b180f12bc0566/HTAlt.Standart/Tools.cs#L542) project includes a method for detecting this, I recommend either using the package or just copying that part and use it in your project. 